### PR TITLE
Locally use the options to read the port

### DIFF
--- a/lib-src/cfenv.coffee
+++ b/lib-src/cfenv.coffee
@@ -166,7 +166,7 @@ getServices = (appEnv, options) ->
 
 #-------------------------------------------------------------------------------
 getPort = (appEnv) ->
-  portString = process.env.PORT || process.env.CF_INSTANCE_PORT || process.env.VCAP_APP_PORT || AppEnv?.app?.port
+  portString = process.env.PORT || process.env.CF_INSTANCE_PORT || process.env.VCAP_APP_PORT || appEnv?.app?.port
 
   unless portString?
     return 3000 unless appEnv.name?

--- a/lib-src/cfenv.coffee
+++ b/lib-src/cfenv.coffee
@@ -166,7 +166,7 @@ getServices = (appEnv, options) ->
 
 #-------------------------------------------------------------------------------
 getPort = (appEnv) ->
-  portString = process.env.PORT || process.env.CF_INSTANCE_PORT || process.env.VCAP_APP_PORT
+  portString = process.env.PORT || process.env.CF_INSTANCE_PORT || process.env.VCAP_APP_PORT || AppEnv?.app?.port
 
   unless portString?
     return 3000 unless appEnv.name?

--- a/lib/cfenv.js
+++ b/lib/cfenv.js
@@ -216,7 +216,7 @@
 
   getPort = function(appEnv) {
     var port, portString, ref;
-    portString = process.env.PORT || process.env.CF_INSTANCE_PORT || process.env.VCAP_APP_PORT || (AppEnv != null ? (ref = AppEnv.app) != null ? ref.port : void 0 : void 0);
+    portString = process.env.PORT || process.env.CF_INSTANCE_PORT || process.env.VCAP_APP_PORT || (appEnv != null ? (ref = appEnv.app) != null ? ref.port : void 0 : void 0);
     if (portString == null) {
       if (appEnv.name == null) {
         return 3000;

--- a/lib/cfenv.js
+++ b/lib/cfenv.js
@@ -215,8 +215,8 @@
   };
 
   getPort = function(appEnv) {
-    var port, portString;
-    portString = process.env.PORT || process.env.CF_INSTANCE_PORT || process.env.VCAP_APP_PORT;
+    var port, portString, ref;
+    portString = process.env.PORT || process.env.CF_INSTANCE_PORT || process.env.VCAP_APP_PORT || (AppEnv != null ? (ref = AppEnv.app) != null ? ref.port : void 0 : void 0);
     if (portString == null) {
       if (appEnv.name == null) {
         return 3000;


### PR DESCRIPTION
We were trying to use the library with providing the vcapFile, but whenever we change the application port it's not reflected in the returned port. 

It's a really simple fix, but we would want to hear your opinion and if possible to merge it back.