### PR TITLE
Upgrade underscore version 1.9.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "dependencies": {
         "js-yaml": "3.11.x",
         "ports": "1.1.x",
-        "underscore": "1.8.x"
+        "underscore": "1.9.x"
     },
     "devDependencies": {
         "coffeescript": "1.12.x",


### PR DESCRIPTION
Ran into the following error when behind a corporate firewall and adding cfenv to a project from npm:

`An unexpected error occurred: "http://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz: Request failed \"403 Forbidden\"".`

We tested adding underscore 1.8.3 by itself to our project and got the same error as above.  Adding underscore 1.9.x worked fine, so our assumption is that upgrading underscore to 1.9.x will resolve this problem for cfenv for users behind a corporate firewall.

