### PR TITLE
Upgrade js-yaml to avoid Denial of Service

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
         "watch": "jbuild watch"
     },
     "dependencies": {
-        "js-yaml": "3.11.x",
+        "js-yaml": "3.13.x",
         "ports": "1.1.x",
         "underscore": "1.9.x"
     },


### PR DESCRIPTION
Based on the [npm audit](https://www.npmjs.com/advisories/788), there is an security issue with `js-yaml`, so upgrade to the latest version to fix. 
And with the latest `js-yaml` version, all the test cases can still pass.