### PR TITLE
handle ports race condition by returning 3000

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 tmp
 npm-debug.log
+.vscode

--- a/lib-src/cfenv.coffee
+++ b/lib-src/cfenv.coffee
@@ -174,7 +174,10 @@ getPort = (appEnv) ->
   unless portString?
     return 3000 unless appEnv.name?
 
-    portString = "#{ports.getPort appEnv.name}"
+    try
+      portString = "#{ports.getPort appEnv.name}"
+    catch e
+      portString = '3000'
 
   port = parseInt portString, 10
   throwError "invalid PORT value: /#{portString}/" if isNaN port

--- a/lib/cfenv.js
+++ b/lib/cfenv.js
@@ -215,13 +215,18 @@
   };
 
   getPort = function(appEnv) {
-    var port, portString, ref;
+    var e, port, portString, ref;
     portString = process.env.PORT || process.env.CF_INSTANCE_PORT || process.env.VCAP_APP_PORT || (appEnv != null ? (ref = appEnv.app) != null ? ref.port : void 0 : void 0);
     if (portString == null) {
       if (appEnv.name == null) {
         return 3000;
       }
-      portString = "" + (ports.getPort(appEnv.name));
+      try {
+        portString = "" + (ports.getPort(appEnv.name));
+      } catch (error) {
+        e = error;
+        portString = '3000';
+      }
     }
     port = parseInt(portString, 10);
     if (isNaN(port)) {


### PR DESCRIPTION
fixes https://github.com/cloudfoundry-community/node-cfenv/issues/40

This is a very simple to fix to the problem with ports where it
will occaisonally throw an error:

- https://github.com/hoodiehq-archive/node-ports/issues/4

The fix is to catch the error and use port 3000.  Not great, but should
handle some cases where this was a problem.

An alternate fix to try would be to try fetching the port again, probably
in a loop (with some limit), in hopes of getting a value from ports.