### PR TITLE
Update package.json - Security Fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "dependencies": {
         "js-yaml": "3.13.x",
         "ports": "1.1.x",
-        "underscore": "1.9.x"
+        "underscore": "1.3.1"
     },
     "devDependencies": {
         "coffeescript": "1.12.x",


### PR DESCRIPTION
Current versions of underscore have a a vulnerability. The most recent non-vulnerable version is 1.3.1 and that is why it is specified that way.