### PR TITLE
update dependencies, now at version 1.2.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,26 @@ When you visit the site, you'll see the output of various cfenv calls.
 changes
 ================================================================================
 
+**1.2.4** - 2021/04/03
+
+- upgrade most dependencies, but not CoffeeScript, since the latest
+  version generates code that can't be run in older versions of node - [pr #50][]
+
+- change to call `yaml.load()` instead of `yaml.safeLoad()` since it's no
+  longer supported, noticed via an error message: - [pr #50][]
+
+  ```
+  Error: Function yaml.safeLoad is removed in js-yaml 4. Use yaml.load instead, which is now safe by default.
+  ```
+
+[pr #50]: https://github.com/cloudfoundry-community/node-cfenv/pull/50
+
+**1.2.3** - 2020/07/24
+
+- remove `.cfignore` file - [commit #02bb92d][]
+
+[commit #02bb92d]: https://github.com/cloudfoundry-community/node-cfenv/commit/02bb92dacf5f59244b188dae11fd2fe732c4940e
+
 **1.2.2** - 2019/03/26
 
 - handle ports package race condition by returning port 3000 - [pr #41][]

--- a/jbuild.coffee
+++ b/jbuild.coffee
@@ -68,7 +68,7 @@ tasks.test = ->
         ui:         "bdd"
         reporter:   "spec"
         slow:       300
-        compilers:  "coffee:coffeescript"
+    #   compilers:  "coffee:coffeescript"
         require:    "coffeescript/register"
 
     options = for key, val of options

--- a/lib-src/cfenv.coffee
+++ b/lib-src/cfenv.coffee
@@ -193,7 +193,7 @@ getName = (appEnv, options) ->
 
   if fs.existsSync "manifest.yml"
     yString = fs.readFileSync "manifest.yml", "utf8"
-    yObject = yaml.safeLoad yString, filename: "manifest.yml"
+    yObject = yaml.load yString, filename: "manifest.yml"
 
     yObject = yObject.applications[0] if yObject.applications?
     return yObject.name if yObject.name?

--- a/lib/cfenv.js
+++ b/lib/cfenv.js
@@ -246,7 +246,7 @@
     }
     if (fs.existsSync("manifest.yml")) {
       yString = fs.readFileSync("manifest.yml", "utf8");
-      yObject = yaml.safeLoad(yString, {
+      yObject = yaml.load(yString, {
         filename: "manifest.yml"
       });
       if (yObject.applications != null) {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "cfenv",
     "main": "./lib/cfenv",
     "description": "easy access to your Cloud Foundry application environment",
-    "version": "1.2.3",
+    "version": "1.2.4",
     "author": "pmuellr",
     "license": "Apache-2.0",
     "homepage": "https://github.com/cloudfoundry-community/node-cfenv",
@@ -17,14 +17,14 @@
         "watch": "jbuild watch"
     },
     "dependencies": {
-        "js-yaml": "3.13.x",
+        "js-yaml": "4.0.x",
         "ports": "1.1.x",
-        "underscore": "1.9.x"
+        "underscore": "1.12.x"
     },
     "devDependencies": {
         "coffeescript": "1.12.x",
         "expect.js": "0.3.x",
         "jbuild": "1.0.x",
-        "mocha": "5.1.x"
+        "mocha": "8.3.x"
     }
 }


### PR DESCRIPTION
- upgrade most dependencies, but not CoffeeScript, since the latest
  version generates code that can't be run in older versions of node

- change to call `yaml.load()` instead of `yaml.safeLoad()` since it's no
  longer supported, noticed via an error message:

  ```
  Error: Function yaml.safeLoad is removed in js-yaml 4. Use yaml.load instead, which is now safe by default.
  ```