### PR TITLE
Update js-yaml version due to CVE 2025-64718

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,12 @@ When you visit the site, you'll see the output of various cfenv calls.
 changes
 ================================================================================
 
+**1.2.5** - 2025/11/26
+
+- upgrade js-yaml to avoid vulnerability - [pr #55][]
+
+[pr #55]: https://github.com/cloudfoundry-community/node-cfenv/pull/55
+
 **1.2.4** - 2021/04/03
 
 - upgrade most dependencies, but not CoffeeScript, since the latest

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
         "watch": "jbuild watch"
     },
     "dependencies": {
-        "js-yaml": "4.0.x",
+        "js-yaml": "4.1.x",
         "ports": "1.1.x",
         "underscore": "1.12.x"
     },


### PR DESCRIPTION
Related to: https://github.com/cloudfoundry-community/node-cfenv/issues/54
No breaking changes in [4.1.0](https://github.com/nodeca/js-yaml/compare/4.0.0...4.1.0): https://github.com/nodeca/js-yaml/blob/master/CHANGELOG.md#410---2021-04-15