### PR TITLE
Upgrade underscore to address security vulnerability CVE-2026-27601 in underscore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules
 tmp
 npm-debug.log
 .vscode
+.idea/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -325,6 +325,10 @@ When you visit the site, you'll see the output of various cfenv calls.
 changes
 ================================================================================
 
+**1.2.6** - 2026/04/16
+
+- upgrade `underscore` to `1.13.x` to address `CVE-2026-27601` and [GHSA-qpx9-hpmf-5gmw](https://github.com/advisories/GHSA-qpx9-hpmf-5gmw) - pr #58
+
 **1.2.5** - 2025/12/01
 
 - upgrade `js.yaml` to 4.1.x for [CVE-2025-64718][] - [pr #56][]

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "cfenv",
     "main": "./lib/cfenv",
     "description": "easy access to your Cloud Foundry application environment",
-    "version": "1.2.5",
+    "version": "1.2.6",
     "author": "pmuellr",
     "license": "Apache-2.0",
     "homepage": "https://github.com/cloudfoundry-community/node-cfenv",
@@ -19,7 +19,7 @@
     "dependencies": {
         "js-yaml": "4.1.x",
         "ports": "1.1.x",
-        "underscore": "1.12.x"
+        "underscore": "1.13.x"
     },
     "devDependencies": {
         "coffeescript": "1.12.x",


### PR DESCRIPTION
This updates the `underscore` dependency to address a security vulnerability with CVSS 8.2. All tests pass and there should be no relevant breaking changes in the underlying dependency. This resolves issue #57.

* Upgraded the `underscore` dependency from `1.12.x` to `1.13.x` in `package.json` to address CVE-2026-27601 and [GHSA-qpx9-hpmf-5gmw](https://github.com/advisories/GHSA-qpx9-hpmf-5gmw).
* Documented the `underscore` upgrade and its security context in the `README.md` changelog.
* Updated the package version from `1.2.5` to `1.2.6` in `package.json` to reflect the dependency and security update.
* Ignored irrelevant files/folders (`.idea/` and `.DS_Store`).