### PR TITLE
Upgrade underscore and js-yaml because of CVEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,13 @@ When you visit the site, you'll see the output of various cfenv calls.
 changes
 ================================================================================
 
+**1.2.7** - 2026/07/27
+
+- upgrade `underscore` to `^1.13.8` to address [`CVE-2026-27601`](https://nvd.nist.gov/vuln/detail/CVE-2026-27601)
+- upgrade `js-yaml` to `^4.3.0` to address [`CVE-2026-53550`](https://nvd.nist.gov/vuln/detail/CVE-2026-53550)
+
+Both CVEs were noted in issue https://github.com/cloudfoundry-community/node-cfenv/issues/59
+
 **1.2.6** - 2026/04/16
 
 - upgrade `underscore` to `1.13.x` to address `CVE-2026-27601` and [GHSA-qpx9-hpmf-5gmw](https://github.com/advisories/GHSA-qpx9-hpmf-5gmw) - pr #58

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "cfenv",
     "main": "./lib/cfenv",
     "description": "easy access to your Cloud Foundry application environment",
-    "version": "1.2.6",
+    "version": "1.2.7",
     "author": "pmuellr",
     "license": "Apache-2.0",
     "homepage": "https://github.com/cloudfoundry-community/node-cfenv",
@@ -17,14 +17,14 @@
         "watch": "jbuild watch"
     },
     "dependencies": {
-        "js-yaml": "4.1.x",
-        "ports": "1.1.x",
-        "underscore": "1.13.x"
+        "js-yaml": "^4.3.0",
+        "ports": "^1.1.0",
+        "underscore": "^1.13.8"
     },
     "devDependencies": {
-        "coffeescript": "1.12.x",
-        "expect.js": "0.3.x",
-        "jbuild": "1.0.x",
-        "mocha": "8.3.x"
+        "coffeescript": "^1.12.7",
+        "expect.js": "^0.3.1",
+        "jbuild": "^1.0.1",
+        "mocha": "^8.4.0"
     }
 }


### PR DESCRIPTION
resolves https://github.com/cloudfoundry-community/node-cfenv/issues/59

- `underscore` to `^1.13.8`
  - [`CVE-2026-27601`](https://nvd.nist.gov/vuln/detail/CVE-2026-27601)

- `js-yaml` to `^4.3.0`
  - [`CVE-2026-53550`](https://nvd.nist.gov/vuln/detail/CVE-2026-53550)